### PR TITLE
Adding apk upgrade's and build script

### DIFF
--- a/alpine/Dockerfile.3.3-armhf
+++ b/alpine/Dockerfile.3.3-armhf
@@ -10,6 +10,7 @@ from multiarch/alpine:armhf-edge
 RUN echo "http://dl-3.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories && \
     echo "http://dl-3.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories && \
     echo "http://dl-3.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories && \
+    apk upgrade --update-cache --available && \
     apk add --update alpine-keys && \
     apk add --update bash automake make git rsync tar wget python py-setuptools \
        gcc g++ gfortran binutils libgcc libstdc++ libgfortran \

--- a/alpine/Dockerfile.3.3-x86_64
+++ b/alpine/Dockerfile.3.3-x86_64
@@ -2,6 +2,7 @@ from multiarch/alpine:x86_64-v3.3
 RUN echo "http://dl-3.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories && \
     echo "http://dl-3.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories && \
     echo "http://dl-3.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories && \
+    apk upgrade --update-cache --available && \
     apk add --update alpine-keys && \
     apk add bash automake make git rsync tar wget python py-setuptools \
        gcc g++ gfortran binutils libgcc libstdc++ libquadmath libgfortran \

--- a/alpine/Dockerfile.3.9-armhf
+++ b/alpine/Dockerfile.3.9-armhf
@@ -10,6 +10,7 @@ from multiarch/alpine:armhf-edge
 RUN echo "http://dl-3.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories && \
     echo "http://dl-3.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories && \
     echo "http://dl-3.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories && \
+    apk upgrade --update-cache --available && \
     apk add --update alpine-keys && \
     apk add bash automake make git rsync tar wget python py-setuptools \
        gcc g++ gfortran binutils libgcc libstdc++ libgfortran \

--- a/alpine/Dockerfile.3.9-x86
+++ b/alpine/Dockerfile.3.9-x86
@@ -2,6 +2,7 @@ from multiarch/alpine:x86-v3.9
 RUN echo "http://dl-3.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories && \
     echo "http://dl-3.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories && \
     echo "http://dl-3.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories && \
+    apk upgrade --update-cache --available && \
     apk add --update alpine-keys && \
     apk add bash automake make git rsync tar wget python py-setuptools \
        gcc g++ gfortran binutils libgcc libstdc++ libquadmath libgfortran \

--- a/alpine/Dockerfile.3.9-x86_64
+++ b/alpine/Dockerfile.3.9-x86_64
@@ -2,6 +2,7 @@ from multiarch/alpine:x86_64-v3.9
 RUN echo "http://dl-3.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories && \
     echo "http://dl-3.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories && \
     echo "http://dl-3.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories && \
+    apk upgrade --update-cache --available && \
     apk add --update alpine-keys && \
     apk add bash automake make git rsync tar wget python py-setuptools \
        gcc g++ gfortran binutils libgcc libstdc++ libquadmath libgfortran \

--- a/alpine/build-all.sh
+++ b/alpine/build-all.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+docker build -t mdsplus/docker:alpine-3.3-armhf -f Dockerfile.3.3-armhf . &
+docker build -t mdsplus/docker:alpine-3.3-x86 -f Dockerfile.3.3-x86 . &
+docker build -t mdsplus/docker:alpine-3.3-x86_64 -f Dockerfile.3.3-x86_64 . &
+docker build -t mdsplus/docker:alpine-3.9-armhf -f Dockerfile.3.3-armhf . &
+docker build -t mdsplus/docker:alpine-3.9-x86 -f Dockerfile.3.3-x86 . &
+docker build -t mdsplus/docker:alpine-3.9-x86_64 -f Dockerfile.3.3-x86_64 . &


### PR DESCRIPTION
Adding `apk upgrade --update-cache --available` to fix the dependency conflicts.
Adding `build-all.sh` as a quick helper script.