### PR TITLE
Fix: Add a pip2 install for importlib

### DIFF
--- a/builder/rhel6/Dockerfile
+++ b/builder/rhel6/Dockerfile
@@ -106,6 +106,7 @@ RUN export repo=/etc/yum.repos.d/devtools-2.repo\
  && cpanm TAP::Parser\
 # pip 
  && pip2 install --upgrade nose tap tap.py\
+ && pip2 install importlib\
  && echo . /opt/rh/devtoolset-2/enable >> /etc/profile\
 # cleanup
  && rm -rf ~\


### PR DESCRIPTION
Dockerfile for RHL6 has been updated to have pip2 install the importlib library.