### PR TITLE
Now uses Python3.12 so include associated NumPy

### DIFF
--- a/builder/rocky-8-x86_64/Dockerfile
+++ b/builder/rocky-8-x86_64/Dockerfile
@@ -57,6 +57,8 @@ RUN yum -q -y install epel-release dnf-plugins-core \
         python3.11-devel \
         python3.11-libs \
         python3.11-numpy \
+        # because python3.6 is somehow upgraded to python3.12, also need numpy
+        python3.12-numpy \
         readline-devel \
         rpm-build \
         rpm-sign \


### PR DESCRIPTION
Jenkins builds are failing on ~45 RHEL8 tests.   The root cause is that the Python 3.6 of the base Rocky-8 image is now somehow getting upgraded to Python 3.12.   Therefore, the automated tests are running Python 3.12 and failing because there is not an associated NumPy.

This PR fixes that problem by also including `python3.12-numpy`.